### PR TITLE
Implement relative move and stall calibration

### DIFF
--- a/serial_ui.py
+++ b/serial_ui.py
@@ -55,7 +55,7 @@ class Ui_SerialWidget(object):
             'btnABSStop', 'btnPanType', 'comboPanMethod', 'btnABSAngleStop',
             'editABSPos', 'editABS2Pos', 'editABSAngle', 'editABSAngle2',
             'btnRelUp', 'btnRelDown', 'btnRelLeft', 'btnRelRight', 'btnRelStop',
-            'editRelStep', 'btnHome',
+            'editRelStep', 'btnStallCaliOn', 'btnStallCaliOff', 'btnHome',
             'chartSpeed', 'btnShowSpeed', 'btnStopSpeed', 'btnClearChart']:
             setattr(self, name, getattr(self.tabMainUi, name))
         self.tabWidget.addTab(self.tabMain, "")

--- a/tab_main.ui
+++ b/tab_main.ui
@@ -214,13 +214,36 @@
           <widget class="QLineEdit" name="editRelStep"/>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnHome">
-        <property name="text">
-         <string>Home</string>
-        </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupStall">
+       <property name="title">
+        <string>Stall Cali.</string>
+       </property>
+       <layout class="QHBoxLayout" name="layoutStall">
+        <item>
+         <widget class="QPushButton" name="btnStallCaliOn">
+          <property name="text">
+           <string>On</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnStallCaliOff">
+          <property name="text">
+           <string>Off</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnHome">
+       <property name="text">
+        <string>Home</string>
+       </property>
        </widget>
       </item>
      </layout>

--- a/tab_main_ui.py
+++ b/tab_main_ui.py
@@ -117,6 +117,19 @@ class Ui_MainTab(object):
 
         self.layoutPanTilt.addWidget(self.groupRelative)
 
+        self.groupStall = QtWidgets.QGroupBox(self.groupPanTilt)
+        self.groupStall.setObjectName("groupStall")
+        self.layoutStall = QtWidgets.QHBoxLayout(self.groupStall)
+        self.layoutStall.setObjectName("layoutStall")
+        self.btnStallCaliOn = QtWidgets.QPushButton(self.groupStall)
+        self.btnStallCaliOn.setObjectName("btnStallCaliOn")
+        self.layoutStall.addWidget(self.btnStallCaliOn)
+        self.btnStallCaliOff = QtWidgets.QPushButton(self.groupStall)
+        self.btnStallCaliOff.setObjectName("btnStallCaliOff")
+        self.layoutStall.addWidget(self.btnStallCaliOff)
+
+        self.layoutPanTilt.addWidget(self.groupStall)
+
         self.btnHome = QtWidgets.QPushButton(self.groupPanTilt)
         self.btnHome.setObjectName("btnHome")
         self.layoutPanTilt.addWidget(self.btnHome)
@@ -175,6 +188,10 @@ class Ui_MainTab(object):
         self.btnRelRight.setText(_translate("MainTab", "Right"))
         self.btnRelDown.setText(_translate("MainTab", "Down"))
         self.labelRelStep.setText(_translate("MainTab", "Step"))
+
+        self.groupStall.setTitle(_translate("MainTab", "Stall Cali."))
+        self.btnStallCaliOn.setText(_translate("MainTab", "On"))
+        self.btnStallCaliOff.setText(_translate("MainTab", "Off"))
 
         self.btnHome.setText(_translate("MainTab", "Home"))
         self.btnShowSpeed.setText(_translate("MainTab", "Show Speed"))

--- a/ui_main.py
+++ b/ui_main.py
@@ -70,6 +70,7 @@ class SerialWindow(QtWidgets.QWidget):
         self.config_data.load(CONFIG_FILE)
         self.comm = None
         self.connected = False
+        self.pending_cmd = None
 
         self.data_received.connect(self.handle_rx)
 
@@ -110,6 +111,13 @@ class SerialWindow(QtWidgets.QWidget):
         self.ui.btnABSAngleStop.clicked.connect(self.abs_angle_stop)
         self.ui.btnPanType.clicked.connect(self.get_pan_type)
         self.ui.comboPanMethod.currentIndexChanged.connect(self.set_pan_method)
+        self.ui.btnRelUp.clicked.connect(self.rel_up)
+        self.ui.btnRelDown.clicked.connect(self.rel_down)
+        self.ui.btnRelLeft.clicked.connect(self.rel_left)
+        self.ui.btnRelRight.clicked.connect(self.rel_right)
+        self.ui.btnRelStop.clicked.connect(self.rel_stop)
+        self.ui.btnStallCaliOn.clicked.connect(self.stall_cali_on)
+        self.ui.btnStallCaliOff.clicked.connect(self.stall_cali_off)
         self.ui.btnHome.clicked.connect(self.go_home)
 
         self.speed_timer = QtCore.QTimer(self)
@@ -129,6 +137,7 @@ class SerialWindow(QtWidgets.QWidget):
             self.config_data.port_name = self.ui.comboPort.currentText()
             self.comm = SerialComm(config=self.config_data, on_rx_char=self.on_rx)
             self.comm.open()
+            self.pending_cmd = 'version'
             self.send_command(VERSION_CMD)
             self.ui.btnOnline.setText("OffLine")
             self.connected = True
@@ -297,7 +306,55 @@ class SerialWindow(QtWidgets.QWidget):
         cmd = bytes([0x81, 0x01, 0x06, 0x06, 0x00, 0x00, 0xFF])
         self.send_command(cmd)
 
+    def relative_move(self, pan_dir=None, tilt_dir=None):
+        step_text = self.ui.editRelStep.text() or "0"
+        step = int(step_text)
+        speed = self.get_speed_level()
+        cmd = bytearray([0x81, 0x01, 0x06, 0x03, 0x00, 0x00,
+                         0x00, 0x00, 0x00, 0x00, 0x00,
+                         0x00, 0x00, 0x00, 0x00, 0x00, 0xFF])
+        if pan_dir is not None:
+            cmd[4] = speed
+            cmd[6] = 0x00 if pan_dir == 'left' else 0x01
+            cmd[7] = (step >> 12) & 0x0F
+            cmd[8] = (step >> 8) & 0x0F
+            cmd[9] = (step >> 4) & 0x0F
+            cmd[10] = step & 0x0F
+        if tilt_dir is not None:
+            cmd[5] = speed
+            cmd[11] = 0x00 if tilt_dir == 'up' else 0x01
+            cmd[12] = (step >> 12) & 0x0F
+            cmd[13] = (step >> 8) & 0x0F
+            cmd[14] = (step >> 4) & 0x0F
+            cmd[15] = step & 0x0F
+        self.send_command(bytes(cmd))
+
+    def rel_left(self):
+        self.relative_move(pan_dir='left')
+
+    def rel_right(self):
+        self.relative_move(pan_dir='right')
+
+    def rel_up(self):
+        self.relative_move(tilt_dir='up')
+
+    def rel_down(self):
+        self.relative_move(tilt_dir='down')
+
+    def rel_stop(self):
+        cmd = bytes([0x81, 0x01, 0x06, 0x03, 0x00, 0x00, 0xFF])
+        self.send_command(cmd)
+
+    def stall_cali_on(self):
+        cmd = bytes([0x81, 0xD1, 0x06, 0x05, 0x02, 0xFF])
+        self.send_command(cmd)
+
+    def stall_cali_off(self):
+        cmd = bytes([0x81, 0xD1, 0x06, 0x05, 0x03, 0xFF])
+        self.send_command(cmd)
+
     def get_pan_type(self):
+        self.pending_cmd = 'pan_type'
         cmd = bytes([0x81, 0xD9, 0x06, 0x02, 0xFF])
         self.send_command(cmd)
 
@@ -322,12 +379,18 @@ class SerialWindow(QtWidgets.QWidget):
         if 0xFF in data:
             idx = data.index(0xFF)
             packet = data[:idx+1]
-            if len(packet) >= 8:
+            if self.pending_cmd == 'pan_type' and len(packet) >= 3:
+                value = packet[2] & 0x03
+                if value < self.ui.comboPanMethod.count():
+                    self.ui.comboPanMethod.setCurrentIndex(value)
+                self.pending_cmd = None
+            elif self.pending_cmd == 'version' and len(packet) >= 8:
                 p5 = f"0{packet[5]}" if packet[5] < 10 else str(packet[5])
                 p6 = f"0{packet[6]}" if packet[6] < 10 else str(packet[6])
                 p7 = f"0{packet[7]}" if packet[7] < 10 else str(packet[7])
                 ver = f"{2000 + packet[4]}{p5}{p6}-{p7}"
                 self.ui.labelFwValue.setText(ver)
+                self.pending_cmd = None
 
         # Split data into packets at 0xFF and format each packet
         packets = []


### PR DESCRIPTION
## Summary
- add Stall Cali. group to the main UI
- expose stall calibration buttons to the main window
- hook up callbacks for relative move and stall calibration
- implement relative move command helper

## Testing
- `python -m py_compile ui_main.py serial_ui.py tab_main_ui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68494ac3ea688330a718b65ea2c89a84