### PR TITLE
Implement relative move and stall calibration

### DIFF
--- a/serial_ui.py
+++ b/serial_ui.py
@@ -15,17 +15,36 @@ class Ui_SerialWidget(object):
         self.btnOnline.setObjectName("btnOnline")
         self.topLayout.addWidget(self.btnOnline)
 
-        self.labelComPort = QtWidgets.QLabel(SerialWidget)
+        self.groupComPort = QtWidgets.QGroupBox(SerialWidget)
+        self.groupComPort.setObjectName("groupComPort")
+        self.layoutComPort = QtWidgets.QHBoxLayout(self.groupComPort)
+        self.layoutComPort.setObjectName("layoutComPort")
+        self.labelComPort = QtWidgets.QLabel(self.groupComPort)
         self.labelComPort.setObjectName("labelComPort")
-        self.topLayout.addWidget(self.labelComPort)
-
-        self.comboPort = QtWidgets.QComboBox(SerialWidget)
+        self.layoutComPort.addWidget(self.labelComPort)
+        self.comboPort = QtWidgets.QComboBox(self.groupComPort)
         self.comboPort.setObjectName("comboPort")
-        self.topLayout.addWidget(self.comboPort)
-
-        self.btnConfigure = QtWidgets.QPushButton(SerialWidget)
+        self.layoutComPort.addWidget(self.comboPort)
+        self.btnConfigure = QtWidgets.QPushButton(self.groupComPort)
         self.btnConfigure.setObjectName("btnConfigure")
-        self.topLayout.addWidget(self.btnConfigure)
+        self.layoutComPort.addWidget(self.btnConfigure)
+        self.topLayout.addWidget(self.groupComPort)
+
+        self.groupMCU = QtWidgets.QGroupBox(SerialWidget)
+        self.groupMCU.setObjectName("groupMCU")
+        self.layoutMCU = QtWidgets.QHBoxLayout(self.groupMCU)
+        self.layoutMCU.setObjectName("layoutMCU")
+        self.comboPTType = QtWidgets.QComboBox(self.groupMCU)
+        self.comboPTType.setObjectName("comboPTType")
+        self.comboPTType.addItems(["Pan", "Tilt"])
+        self.layoutMCU.addWidget(self.comboPTType)
+        self.labelMCUType = QtWidgets.QLabel(self.groupMCU)
+        self.labelMCUType.setObjectName("labelMCUType")
+        self.labelMCUType.setMinimumWidth(60)
+        self.labelMCUType.setFrameShape(QtWidgets.QFrame.Panel)
+        self.labelMCUType.setFrameShadow(QtWidgets.QFrame.Sunken)
+        self.layoutMCU.addWidget(self.labelMCUType)
+        self.topLayout.addWidget(self.groupMCU)
 
         self.labelFw = QtWidgets.QLabel(SerialWidget)
         self.labelFw.setObjectName("labelFw")
@@ -55,7 +74,7 @@ class Ui_SerialWidget(object):
             'btnABSStop', 'btnPanType', 'comboPanMethod', 'btnABSAngleStop',
             'editABSPos', 'editABS2Pos', 'editABSAngle', 'editABSAngle2',
             'btnRelUp', 'btnRelDown', 'btnRelLeft', 'btnRelRight', 'btnRelStop',
-            'editRelStep', 'btnHome',
+            'editRelStep', 'btnStallCaliOn', 'btnStallCaliOff', 'btnHome',
             'chartSpeed', 'btnShowSpeed', 'btnStopSpeed', 'btnClearChart']:
             setattr(self, name, getattr(self.tabMainUi, name))
         self.tabWidget.addTab(self.tabMain, "")
@@ -163,8 +182,12 @@ class Ui_SerialWidget(object):
         _translate = QtCore.QCoreApplication.translate
         SerialWidget.setWindowTitle(_translate("SerialWidget", "Serial Tester"))
         self.btnOnline.setText(_translate("SerialWidget", "OnLine"))
-        self.labelComPort.setText(_translate("SerialWidget", "ComPort:"))
+        self.groupComPort.setTitle(_translate("SerialWidget", "ComPort"))
+        self.labelComPort.setText(_translate("SerialWidget", "Port:"))
         self.btnConfigure.setText(_translate("SerialWidget", "Configure"))
+        self.groupMCU.setTitle(_translate("SerialWidget", "MCU"))
+        self.comboPTType.setItemText(0, _translate("SerialWidget", "Pan"))
+        self.comboPTType.setItemText(1, _translate("SerialWidget", "Tilt"))
         self.labelFw.setText(_translate("SerialWidget", "FW Version:"))
         self.labelFwValue.setText("")
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabMain), _translate("SerialWidget", "Main"))

--- a/serial_ui.ui
+++ b/serial_ui.ui
@@ -12,20 +12,68 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="labelComPort">
-       <property name="text">
-        <string>ComPort:</string>
+      <widget class="QGroupBox" name="groupComPort">
+       <property name="title">
+        <string>ComPort</string>
        </property>
+       <layout class="QHBoxLayout" name="layoutComPort">
+        <item>
+         <widget class="QLabel" name="labelComPort">
+          <property name="text">
+           <string>Port:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboPort"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnConfigure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboPort"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnConfigure">
-       <property name="text">
-        <string>Configure</string>
+      <widget class="QGroupBox" name="groupMCU">
+       <property name="title">
+        <string>MCU</string>
        </property>
+       <layout class="QHBoxLayout" name="layoutMCU">
+        <item>
+         <widget class="QComboBox" name="comboPTType">
+          <item>
+           <property name="text">
+            <string>Pan</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Tilt</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelMCUType">
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::Panel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Sunken</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item>

--- a/tab_main.ui
+++ b/tab_main.ui
@@ -85,6 +85,13 @@
          <item row="0" column="1">
           <widget class="QLineEdit" name="editABSPos"/>
          </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="btnABSStop">
+           <property name="text">
+            <string>ABS Stop</string>
+           </property>
+          </widget>
+         </item>
          <item row="1" column="0">
           <widget class="QPushButton" name="btnABS2">
            <property name="text">
@@ -94,6 +101,41 @@
          </item>
          <item row="1" column="1">
           <widget class="QLineEdit" name="editABS2Pos"/>
+         </item>
+         <item row="1" column="2" rowspan="2">
+          <widget class="QGroupBox" name="groupPanType">
+           <property name="title">
+            <string>Pan Direction</string>
+           </property>
+           <layout class="QVBoxLayout" name="layoutPanType">
+            <item>
+             <widget class="QPushButton" name="btnPanType">
+              <property name="text">
+               <string>Get Pan Type</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboPanMethod">
+              <item>
+               <property name="text">
+                <string>Shorter Path</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Forced CW</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Forced CCW</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </item>
          <item row="2" column="0">
           <widget class="QPushButton" name="btnABSAngle">
@@ -115,44 +157,7 @@
          <item row="3" column="1">
           <widget class="QLineEdit" name="editABSAngle2"/>
          </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QPushButton" name="btnABSStop">
-           <property name="text">
-            <string>ABS Stop</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0" colspan="2">
-          <layout class="QHBoxLayout" name="layoutPanType">
-           <item>
-            <widget class="QPushButton" name="btnPanType">
-             <property name="text">
-              <string>Get Pan Type</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="comboPanMethod">
-             <item>
-              <property name="text">
-               <string>Shorter Path</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Forced CW</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Forced CCW</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="6" column="0" colspan="2">
+         <item row="3" column="2">
           <widget class="QPushButton" name="btnABSAngleStop">
            <property name="text">
             <string>ABS Angle Stop</string>
@@ -214,13 +219,36 @@
           <widget class="QLineEdit" name="editRelStep"/>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnHome">
-        <property name="text">
-         <string>Home</string>
-        </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupStall">
+       <property name="title">
+        <string>Stall Cali.</string>
+       </property>
+       <layout class="QHBoxLayout" name="layoutStall">
+        <item>
+         <widget class="QPushButton" name="btnStallCaliOn">
+          <property name="text">
+           <string>On</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnStallCaliOff">
+          <property name="text">
+           <string>Off</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnHome">
+       <property name="text">
+        <string>Home</string>
+       </property>
        </widget>
       </item>
      </layout>

--- a/tab_main_ui.py
+++ b/tab_main_ui.py
@@ -72,20 +72,24 @@ class Ui_MainTab(object):
         self.gridAbsolute.addWidget(self.editABSAngle2, 3, 1, 1, 1)
         self.btnABSStop = QtWidgets.QPushButton(self.groupAbsolute)
         self.btnABSStop.setObjectName("btnABSStop")
-        self.gridAbsolute.addWidget(self.btnABSStop, 4, 0, 1, 2)
-        self.layoutPanType = QtWidgets.QHBoxLayout()
+        self.gridAbsolute.addWidget(self.btnABSStop, 0, 2, 1, 1)
+
+        self.groupPanType = QtWidgets.QGroupBox(self.groupAbsolute)
+        self.groupPanType.setObjectName("groupPanType")
+        self.layoutPanType = QtWidgets.QVBoxLayout(self.groupPanType)
         self.layoutPanType.setObjectName("layoutPanType")
-        self.btnPanType = QtWidgets.QPushButton(self.groupAbsolute)
+        self.btnPanType = QtWidgets.QPushButton(self.groupPanType)
         self.btnPanType.setObjectName("btnPanType")
         self.layoutPanType.addWidget(self.btnPanType)
-        self.comboPanMethod = QtWidgets.QComboBox(self.groupAbsolute)
+        self.comboPanMethod = QtWidgets.QComboBox(self.groupPanType)
         self.comboPanMethod.setObjectName("comboPanMethod")
         self.comboPanMethod.addItems(["Shorter Path", "Forced CW", "Forced CCW"])
         self.layoutPanType.addWidget(self.comboPanMethod)
-        self.gridAbsolute.addLayout(self.layoutPanType, 5, 0, 1, 2)
+        self.gridAbsolute.addWidget(self.groupPanType, 1, 2, 2, 1)
+
         self.btnABSAngleStop = QtWidgets.QPushButton(self.groupAbsolute)
         self.btnABSAngleStop.setObjectName("btnABSAngleStop")
-        self.gridAbsolute.addWidget(self.btnABSAngleStop, 6, 0, 1, 2)
+        self.gridAbsolute.addWidget(self.btnABSAngleStop, 3, 2, 1, 1)
 
         self.layoutPanTilt.addWidget(self.groupAbsolute)
 
@@ -116,6 +120,19 @@ class Ui_MainTab(object):
         self.gridRelative.addWidget(self.editRelStep, 1, 4, 1, 1)
 
         self.layoutPanTilt.addWidget(self.groupRelative)
+
+        self.groupStall = QtWidgets.QGroupBox(self.groupPanTilt)
+        self.groupStall.setObjectName("groupStall")
+        self.layoutStall = QtWidgets.QHBoxLayout(self.groupStall)
+        self.layoutStall.setObjectName("layoutStall")
+        self.btnStallCaliOn = QtWidgets.QPushButton(self.groupStall)
+        self.btnStallCaliOn.setObjectName("btnStallCaliOn")
+        self.layoutStall.addWidget(self.btnStallCaliOn)
+        self.btnStallCaliOff = QtWidgets.QPushButton(self.groupStall)
+        self.btnStallCaliOff.setObjectName("btnStallCaliOff")
+        self.layoutStall.addWidget(self.btnStallCaliOff)
+
+        self.layoutPanTilt.addWidget(self.groupStall)
 
         self.btnHome = QtWidgets.QPushButton(self.groupPanTilt)
         self.btnHome.setObjectName("btnHome")
@@ -165,6 +182,7 @@ class Ui_MainTab(object):
         self.btnABSAngle.setText(_translate("MainTab", "Angle"))
         self.btnABSAngle2.setText(_translate("MainTab", "Angle2"))
         self.btnABSStop.setText(_translate("MainTab", "ABS Stop"))
+        self.groupPanType.setTitle(_translate("MainTab", "Pan Direction"))
         self.btnPanType.setText(_translate("MainTab", "Get Pan Type"))
         self.btnABSAngleStop.setText(_translate("MainTab", "ABS Angle Stop"))
 
@@ -175,6 +193,10 @@ class Ui_MainTab(object):
         self.btnRelRight.setText(_translate("MainTab", "Right"))
         self.btnRelDown.setText(_translate("MainTab", "Down"))
         self.labelRelStep.setText(_translate("MainTab", "Step"))
+
+        self.groupStall.setTitle(_translate("MainTab", "Stall Cali."))
+        self.btnStallCaliOn.setText(_translate("MainTab", "On"))
+        self.btnStallCaliOff.setText(_translate("MainTab", "Off"))
 
         self.btnHome.setText(_translate("MainTab", "Home"))
         self.btnShowSpeed.setText(_translate("MainTab", "Show Speed"))


### PR DESCRIPTION
## Summary
- add Stall Cali. group to the main UI
- expose stall calibration buttons to the main window
- hook up callbacks for relative move and stall calibration
- implement relative move command helper
- wrap COM port widgets in a new group box
- add MCU group to display and select axis type
- redesign Absolute Move layout to match C# UI

## Testing
- `python -m py_compile ui_main.py serial_ui.py tab_main_ui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68494ac3ea688330a718b65ea2c89a84