### PR TITLE
Enhance UI layout and speed control

### DIFF
--- a/serial_ui.py
+++ b/serial_ui.py
@@ -46,16 +46,23 @@ class Ui_SerialWidget(object):
         self.layoutMCU.addWidget(self.labelMCUType)
         self.topLayout.addWidget(self.groupMCU)
 
-        self.labelFw = QtWidgets.QLabel(SerialWidget)
-        self.labelFw.setObjectName("labelFw")
-        self.topLayout.addWidget(self.labelFw)
+        self.groupFW = QtWidgets.QGroupBox(SerialWidget)
+        self.groupFW.setObjectName("groupFW")
+        self.layoutFW = QtWidgets.QHBoxLayout(self.groupFW)
+        self.layoutFW.setObjectName("layoutFW")
 
-        self.labelFwValue = QtWidgets.QLabel(SerialWidget)
+        self.labelFw = QtWidgets.QLabel(self.groupFW)
+        self.labelFw.setObjectName("labelFw")
+        self.layoutFW.addWidget(self.labelFw)
+
+        self.labelFwValue = QtWidgets.QLabel(self.groupFW)
         self.labelFwValue.setObjectName("labelFwValue")
         self.labelFwValue.setMinimumWidth(100)
         self.labelFwValue.setFrameShape(QtWidgets.QFrame.Panel)
         self.labelFwValue.setFrameShadow(QtWidgets.QFrame.Sunken)
-        self.topLayout.addWidget(self.labelFwValue)
+        self.layoutFW.addWidget(self.labelFwValue)
+
+        self.topLayout.addWidget(self.groupFW)
 
         self.verticalLayout.addLayout(self.topLayout)
 
@@ -160,26 +167,34 @@ class Ui_SerialWidget(object):
 
         self.verticalLayout.addWidget(self.tabWidget)
 
-        self.formLayout = QtWidgets.QFormLayout()
-        self.formLayout.setObjectName("formLayout")
+        self.layoutTxRx = QtWidgets.QHBoxLayout()
+        self.layoutTxRx.setObjectName("layoutTxRx")
 
+        self.layoutTx = QtWidgets.QVBoxLayout()
+        self.layoutTx.setObjectName("layoutTx")
         self.labelTx = QtWidgets.QLabel(SerialWidget)
         self.labelTx.setObjectName("labelTx")
-        self.formLayout.setWidget(0, QtWidgets.QFormLayout.LabelRole, self.labelTx)
-
+        self.layoutTx.addWidget(self.labelTx)
         self.textTx = QtWidgets.QTextEdit(SerialWidget)
         self.textTx.setObjectName("textTx")
-        self.formLayout.setWidget(0, QtWidgets.QFormLayout.FieldRole, self.textTx)
+        self.textTx.setMinimumHeight(200)
+        self.layoutTx.addWidget(self.textTx)
+        self.layoutTxRx.addLayout(self.layoutTx)
 
+        self.layoutRx = QtWidgets.QVBoxLayout()
+        self.layoutRx.setObjectName("layoutRx")
         self.labelRx = QtWidgets.QLabel(SerialWidget)
         self.labelRx.setObjectName("labelRx")
-        self.formLayout.setWidget(1, QtWidgets.QFormLayout.LabelRole, self.labelRx)
-
+        self.layoutRx.addWidget(self.labelRx)
         self.textRx = QtWidgets.QTextEdit(SerialWidget)
         self.textRx.setObjectName("textRx")
-        self.formLayout.setWidget(1, QtWidgets.QFormLayout.FieldRole, self.textRx)
+        self.textRx.setMinimumHeight(200)
+        self.layoutRx.addWidget(self.textRx)
+        self.layoutTxRx.addLayout(self.layoutRx)
+        self.layoutTxRx.setStretch(0, 1)
+        self.layoutTxRx.setStretch(1, 1)
 
-        self.verticalLayout.addLayout(self.formLayout)
+        self.verticalLayout.addLayout(self.layoutTxRx)
 
         self.btnClear = QtWidgets.QPushButton(SerialWidget)
         self.btnClear.setObjectName("btnClear")
@@ -198,6 +213,7 @@ class Ui_SerialWidget(object):
         self.groupMCU.setTitle(_translate("SerialWidget", "MCU"))
         self.comboPTType.setItemText(0, _translate("SerialWidget", "Pan"))
         self.comboPTType.setItemText(1, _translate("SerialWidget", "Tilt"))
+        self.groupFW.setTitle(_translate("SerialWidget", "FW group"))
         self.labelFw.setText(_translate("SerialWidget", "FW Version:"))
         self.labelFwValue.setText("")
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabMain), _translate("SerialWidget", "Main"))

--- a/serial_ui.ui
+++ b/serial_ui.ui
@@ -77,26 +77,35 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="labelFw">
-       <property name="text">
-        <string>FW Version:</string>
+      <widget class="QGroupBox" name="groupFW">
+       <property name="title">
+        <string>FW group</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelFwValue">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Panel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
+       <layout class="QHBoxLayout" name="layoutFW">
+        <item>
+         <widget class="QLabel" name="labelFw">
+          <property name="text">
+           <string>FW Version:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelFwValue">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::Panel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Sunken</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
@@ -323,26 +332,45 @@
     </widget>
    </item>
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelTx">
-       <property name="text">
-        <string>Tx:</string>
-       </property>
-      </widget>
+    <layout class="QHBoxLayout" name="layoutTxRx">
+     <property name="stretch">
+      <string>1,1</string>
+     </property>
+     <item>
+      <layout class="QVBoxLayout" name="layoutTx">
+       <item>
+        <widget class="QLabel" name="labelTx">
+         <property name="text">
+          <string>Tx:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="textTx">
+         <property name="minimumHeight">
+          <number>200</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="0" column="1">
-      <widget class="QTextEdit" name="textTx"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelRx">
-       <property name="text">
-        <string>Rx:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QTextEdit" name="textRx"/>
+     <item>
+      <layout class="QVBoxLayout" name="layoutRx">
+       <item>
+        <widget class="QLabel" name="labelRx">
+         <property name="text">
+          <string>Rx:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="textRx">
+         <property name="minimumHeight">
+          <number>200</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/ui_main.py
+++ b/ui_main.py
@@ -201,7 +201,16 @@ class SerialWindow(QtWidgets.QWidget):
         self.send_command(cmd)
 
     def get_speed_level(self) -> int:
-        return DEFAULT_SPEED_LEVEL
+        text = self.ui.editSpeedLevel.text()
+        if not text:
+            level = DEFAULT_SPEED_LEVEL
+            self.ui.editSpeedLevel.setText(str(level))
+        else:
+            level = int(text)
+        if level == 0:
+            level = 1
+            self.ui.editSpeedLevel.setText(str(level))
+        return level
 
     def send_stop_command(self):
         cmd = bytes([0x81, 0x01, 0x06, 0x01, 0x00, 0x00, 0x03, 0x03, 0xFF])


### PR DESCRIPTION
## Summary
- group firmware labels into a new "FW group" box
- place Tx/Rx displays horizontally with larger text areas
- derive speed level from the UI with bounds checking

## Testing
- `python -m py_compile serial_comm.py serial_config.py serial_port.py serial_ui.py tab_main_ui.py ui_main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6850d2c630f88330b0f3d763b51d6561